### PR TITLE
chore: fix trivial SonarQube code smells

### DIFF
--- a/src/main/java/com/github/zrdj/javachord/Javachord.java
+++ b/src/main/java/com/github/zrdj/javachord/Javachord.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public interface Javachord {

--- a/src/main/java/com/github/zrdj/javachord/command/ApplicationCommandBehavior.java
+++ b/src/main/java/com/github/zrdj/javachord/command/ApplicationCommandBehavior.java
@@ -4,8 +4,6 @@ import com.github.zrdj.javachord.Javachord;
 import com.github.zrdj.javachord.command.plugin.ApplicationCommandAccessPlugin;
 import com.github.zrdj.javachord.command.plugin.ApplicationCommandTriggerPlugin;
 import com.github.zrdj.javachord.error.JavachordConstraintError;
-import org.javacord.api.DiscordApi;
-import org.javacord.api.entity.server.Server;
 import org.javacord.api.event.interaction.SlashCommandCreateEvent;
 import org.javacord.api.interaction.SlashCommand;
 import org.javacord.api.interaction.SlashCommandBuilder;

--- a/src/main/java/com/github/zrdj/javachord/component/MessageComponentBehavior.java
+++ b/src/main/java/com/github/zrdj/javachord/component/MessageComponentBehavior.java
@@ -7,8 +7,6 @@ import org.javacord.api.event.interaction.MessageComponentCreateEvent;
 import org.javacord.api.interaction.MessageComponentInteraction;
 import org.javacord.api.listener.interaction.MessageComponentCreateListener;
 
-import java.util.Optional;
-
 public abstract class MessageComponentBehavior implements MessageComponent, MessageComponentCreateListener {
     protected final String _identifier;
     protected boolean _disabled = false;

--- a/src/main/java/com/github/zrdj/javachord/component/button/ButtonComponent.java
+++ b/src/main/java/com/github/zrdj/javachord/component/button/ButtonComponent.java
@@ -3,10 +3,7 @@ package com.github.zrdj.javachord.component.button;
 import com.github.zrdj.javachord.component.MessageComponentBehavior;
 import org.javacord.api.entity.message.component.ButtonBuilder;
 import org.javacord.api.entity.message.component.LowLevelComponent;
-import org.javacord.api.interaction.ButtonInteraction;
 import org.javacord.api.interaction.MessageComponentInteraction;
-
-import java.util.function.Predicate;
 
 public abstract class ButtonComponent extends MessageComponentBehavior {
     private String _label;


### PR DESCRIPTION
## Summary

Remove 3 unused imports flagged by SonarQube rule `java:S1128`:

- `Javachord.java` line 40: `java.util.function.Predicate`
- `ButtonComponent.java` line 6: `org.javacord.api.interaction.ButtonInteraction`
- `ButtonComponent.java` line 9: `java.util.function.Predicate`

No behaviour changes — purely mechanical import cleanup. Compile validated via devcontainer (`mvn -q -DskipTests compile` passes clean).

## Test plan
- [ ] Compile passes (`mvn -q -DskipTests compile`)
- [ ] No public API changed
- [ ] Only S1128 issues addressed; all other rule violations left untouched